### PR TITLE
harden: sanitize child_process call in animedunya.js...

### DIFF
--- a/providers/animedunya.js
+++ b/providers/animedunya.js
@@ -1,4 +1,3 @@
-import child_process from "node:child_process";
 import { json, episodeMeta } from "../core/new-provider-utils.js";
 import { getMedia } from "../core/anilist.js";
 import { get as cacheGet, set as cacheSet, isFresh, SHOW_IDENTITY_TTL } from "../core/smartcache.js";
@@ -17,9 +16,16 @@ async function resolveMalId(anilistId) {
   return media.idMal;
 }
 
-function fetchHtml(url) {
-  const cmd = `curl -s -L -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36" -H "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8" -H "Accept-Language: en-US,en;q=0.9" "${url}"`;
-  return child_process.execSync(cmd, { encoding: "utf-8", maxBuffer: 10 * 1024 * 1024 });
+async function fetchHtml(url) {
+  const res = await fetch(url, {
+    headers: {
+      "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+      "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+      "Accept-Language": "en-US,en;q=0.9"
+    }
+  });
+  if (!res.ok) throw new Error(`AnimeDunya: HTTP ${res.status}`);
+  return res.text();
 }
 
 function extractEpisodesList(html) {
@@ -79,7 +85,7 @@ function extractStream(html) {
 
 export async function getEpisodes(anilistId, ctx = {}) {
   const malId = await resolveMalId(anilistId);
-  const html = fetchHtml(`${BASE}/en/anime/${malId}`);
+  const html = await fetchHtml(`${BASE}/en/anime/${malId}`);
   if (!html) throw new Error("AnimeDunya: episodes fetch failed");
 
   let cdnBase = "https://cdn.anime-dunya.com/thumbnail/";
@@ -129,7 +135,7 @@ export async function getEpisodes(anilistId, ctx = {}) {
 
 async function handleWatch(anilistId, audio, epNum) {
   const malId = await resolveMalId(anilistId);
-  const html = fetchHtml(`${BASE}/en/play/${malId}/${epNum}`);
+  const html = await fetchHtml(`${BASE}/en/play/${malId}/${epNum}`);
   if (!html) return json({ error: "AnimeDunya watch fetch failed" }, 500);
 
   const streamData = extractStream(html);


### PR DESCRIPTION
## Summary
Harden input handling in `providers/animedunya.js` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | javascript.lang.security.detect-child-process.detect-child-process |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `javascript.lang.security.detect-child-process.detect-child-process` |
| **File** | `providers/animedunya.js:22` |
| **Assessment** | Defensive hardening |

**Description**: Detected calls to child_process from a function argument `url`. This could lead to a command injection if the input is user controllable. Try to avoid calls to child_process, and if it is needed ensure user input is correctly sanitized or sandboxed. 

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `providers/animedunya.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
